### PR TITLE
Added unit test for short isnb failure

### DIFF
--- a/backend/tests/unit_testing/test_book.py
+++ b/backend/tests/unit_testing/test_book.py
@@ -5,13 +5,6 @@ from app.schemas.book import BookCreate, BookRead, BookUpdate
 
 service = BookService()
 
-# create book with empty isbn
-# create book with short isbn
-# create book with too long isbn
-# test validator with these
-
-
-
 def test_create_book_success():
     expected_result = BookRead(
                         isbn = "9780307245304",
@@ -92,3 +85,16 @@ def test_empty_isbn_fail():
         service.create_book(test_data)  #it won't get here
 
     assert "ISBN must contain exactly 10 or 13 digits" in str(exc_info.value)
+
+def test_short_isbn_fail():
+    with pytest.raises(ValidationError) as exc_info:
+    # This will trigger the Pydantic validator
+        test_data = BookCreate(
+            isbn="11",  
+            book_title="Percy Jackson and the Lightning Thief",
+            author="Rick Riordan"
+        )
+        service.create_book(test_data)  #it won't get here
+
+    assert "ISBN must contain exactly 10 or 13 digits" in str(exc_info.value)
+   


### PR DESCRIPTION
In this PR, I added a unit test for when a book is created with a short ISBN. ISBN's should only be either 10 or 13 digits so this is an important test to have. It also links our validator.


<img width="900" height="688" alt="Screenshot 2025-11-18 at 10 19 50 AM" src="https://github.com/user-attachments/assets/d5a0e4d8-7ea2-490e-bbd8-b125c18bcc52" />
