### PR TITLE
Test/integration/invalid or no rating

### DIFF
--- a/backend/tests/integration_testing/rating_integration_test.py
+++ b/backend/tests/integration_testing/rating_integration_test.py
@@ -75,3 +75,14 @@ def test_create_rating_invalid_value_returns_422(client):
 
     r2 = client.post("/ratings/books/123?user_id=1", json={"rating": -1})
     assert r2.status_code == 422
+
+def test_avg_rating_when_no_ratings(client):
+    r = client.get("/ratings/books/NO_RATINGS/average")
+    assert r.status_code == 200
+    data = r.json()
+    assert data == {"isbn": "NO_RATINGS", "avg_rating": 0.0, "count": 0}
+
+def test_get_user_rating_not_found_returns_null(client):
+    r = client.get("/ratings/users/999/books/UNKNOWN")
+    assert r.status_code == 200
+    assert r.json() is None


### PR DESCRIPTION
Average rating when there are no ratings makes sure the get_avg_rating default path is covered, and getting a user rating that does not exist checks it returns None (which becomes JSON null).

<img width="1201" height="901" alt="image" src="https://github.com/user-attachments/assets/20bbf257-8497-49bd-813a-60da96933ea1" />
