### PR TITLE
Added unit test for long isbn failure

### DIFF
--- a/backend/tests/unit_testing/test_book.py
+++ b/backend/tests/unit_testing/test_book.py
@@ -97,4 +97,17 @@ def test_short_isbn_fail():
         service.create_book(test_data)  #it won't get here
 
     assert "ISBN must contain exactly 10 or 13 digits" in str(exc_info.value)
+
+def test_long_isbn_fail():
+    with pytest.raises(ValidationError) as exc_info:
+    # This will trigger the Pydantic validator
+        test_data = BookCreate(
+            isbn="11111111111111111111111111111111111",  
+            book_title="Percy Jackson and the Lightning Thief",
+            author="Rick Riordan"
+        )
+        service.create_book(test_data)  #it won't get here
+
+    assert "ISBN must contain exactly 10 or 13 digits" in str(exc_info.value)
+   
    


### PR DESCRIPTION
In this PR, I added a unit test for when a book is created with a long ISBN. ISBN's should only be either 10 or 13 digits so this is an important test to have. It also links our validator.

<img width="937" height="683" alt="Screenshot 2025-11-18 at 10 41 54 AM" src="https://github.com/user-attachments/assets/c7548d78-37a1-46f2-8408-75191e19a674" />
