### PR TITLE
Set timezone for report generation job

### DIFF
--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      TZ: America/Vancouver
     defaults:
       run:
         working-directory: backend  # All commands run from /backend


### PR DESCRIPTION
The previous screenshots of pytest and coverage reports were in different time zone so time in reports weren't accurate