### PR TITLE
Refactoring/test rating

### DIFF
--- a/backend/tests/unit_testing/test_rating.py
+++ b/backend/tests/unit_testing/test_rating.py
@@ -1,24 +1,41 @@
+import csv
 import pytest
 from app.services.rating_service import RatingService
 from app.schemas.rating import RatingRead
 
-service = RatingService()
 
-def test_create_rating_success():
+@pytest.fixture
+def service(tmp_path):
+    """Return a fresh RatingService with isolated Ratings.csv."""
+    svc = RatingService()
+    svc.ratings_path = str(tmp_path / "Ratings.csv")
+
+    with open(svc.ratings_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=svc.fields)
+        writer.writeheader()
+
+    return svc
+
+
+def test_create_rating_success(service):
     expected = RatingRead(user_id=1, isbn="034545104X", rating=8)
     result = service.create_rating(1, "034545104X", 8)
     assert result == expected
 
-def test_update_rating_overwrites_value():
+
+def test_update_rating_overwrites_value(service):
     service.create_rating(1, "034545104X", 6)
     service.create_rating(1, "034545104X", 8)
     r = service.get_user_rating(1, "034545104X")
-    assert r and r.rating == 8
+    assert r.rating == 8
 
-def test_get_all_and_delete():
+
+def test_get_all_and_delete(service):
     service.create_rating(2, "1111111111", 6)
+
     rows = service.get_ratings_by_isbn("1111111111")
     assert len(rows) == 1
     assert rows[0].user_id == 2
+
     ok = service.delete_rating(2, "1111111111")
     assert ok is True


### PR DESCRIPTION
Global RatingService violated a bit of SOLID since tests couldn't manage shared service state, it wasn't open to changes and service couldn't be mocked. Now fixed. Since test depended on concrete file path, dependency inversion's been improved by adding tmp_path. Tests still pass.

<img width="1726" height="995" alt="image" src="https://github.com/user-attachments/assets/8cb29b44-205b-491b-8ac6-c9cf0960d79b" />
